### PR TITLE
Added levelExpWeighting

### DIFF
--- a/data/config/config_game_one.properties
+++ b/data/config/config_game_one.properties
@@ -35,3 +35,4 @@ game.rewards.point=1
 game.rewards.kash=1
 game.rewards.practice=false
 game.match.broadcast=false
+game.match.levelExpWeighting=true

--- a/data/config/config_game_two.properties
+++ b/data/config/config_game_two.properties
@@ -35,3 +35,5 @@ game.rewards.point=2
 game.rewards.kash=2
 game.rewards.practice=true
 game.match.broadcast=false
+game.match.levelExpWeighting=true
+


### PR DESCRIPTION
This PR introduces the concept of extra EXP for lower levels. 
These are the rules:

1. You must be a lower level than the average level of the room (including both teams)
2. The exp added is the level difference between you and the average level, doubled, as a percentage.
3. The added exp caps at 75% to discourage farming.

If a lvl 1 plays with 50's the average level is 45 so he gets 90% exp 
however, 75% is the max soo... +75% 
100 - > 190
150 - > 262
300 - > 525
500 - > 875
This is considered an extreme test case

If a lvl 29 plays with 30's the average levels is 29.9 
then + 1.8% exp
100 - > 102
150 - > 152
300 - > 305
500 - > 509
This is considered the smallest test case 

If a lvl 15 plays with 30's the average levels is 28.5 
then + 27% exp
100 - > 127
150 - > 190
300 - > 381
500 - > 635
This is considered a medium test case
